### PR TITLE
Reverting the bench processort fix for bun bug workaround.

### DIFF
--- a/tools/benchmark.processor.ts
+++ b/tools/benchmark.processor.ts
@@ -5,7 +5,7 @@ const suite = data.fullName.split(">")[1].trim();
 const results = (data.benchmarks as { name: string; hz: number }[]).reduce(
   (agg, { name, hz }) => ({
     ...agg,
-    [suite]: { ...agg[suite], [`${name} `]: Math.round(hz) },
+    [suite]: { ...agg[suite], [name]: Math.round(hz) },
   }),
   { [suite]: {} },
 );


### PR DESCRIPTION
fixed in 1.1.31

https://bun.sh/blog/bun-v1.1.31#fixed-format-of-console-table-with-numeric-keys